### PR TITLE
fix: extract tar flags

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@master
         with:
-          version: 10.x
+          version: 12.x
       - run: node ./common/scripts/install-run-rush.js check
       - run: node ./common/scripts/install-run-rush.js change --verify
       - run: node ./common/scripts/install-run-rush.js install

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -31,6 +31,10 @@
       "allowedCategories": [ "default" ]
     },
     {
+      "name": "jest-silent-reporter",
+      "allowedCategories": [ "default" ]
+    },
+    {
       "name": "prettier",
       "allowedCategories": [ "default" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -8,6 +8,7 @@ dependencies:
   '@zeit/ncc': 0.20.4
   jest: 24.9.0
   jest-circus: 24.9.0
+  jest-silent-reporter: 0.1.2
   prettier: 1.18.2
   semver: 6.3.0
   ts-jest: 24.0.2_jest@24.9.0
@@ -2103,6 +2104,9 @@ packages:
       node: '>=6'
     peerDependencies:
       jest-resolve: '*'
+    peerDependenciesMeta:
+      jest-resolve:
+        optional: true
     resolution:
       integrity: sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==
   /jest-regex-util/24.9.0:
@@ -2198,6 +2202,13 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ==
+  /jest-silent-reporter/0.1.2:
+    dependencies:
+      chalk: 2.4.2
+      jest-util: 24.9.0
+    dev: false
+    resolution:
+      integrity: sha512-w/qc9NvWqdX0vZv6TUG4EE15d72+JxQJYh+3hqq8cTi3BnfBOtwNtL3T6TwkZSy/sfc3REW5niz0eSBPTIvWnA==
   /jest-snapshot/24.9.0:
     dependencies:
       '@babel/types': 7.5.5
@@ -3958,6 +3969,7 @@ packages:
       husky: 3.0.4
       jest: 24.9.0
       jest-circus: 24.9.0
+      jest-silent-reporter: 0.1.2
       prettier: 1.18.2
       semver: 6.3.0
       ts-jest: 24.0.2_jest@24.9.0
@@ -3969,7 +3981,7 @@ packages:
     dev: false
     name: '@rush-temp/setup-flutter'
     resolution:
-      integrity: sha512-qE4EM3FxerZ7Rrwv6OYMbggR4RE5ORoBDBg5yN7b15OqbkoGgwwwnjPSmSXcyH8rojMaFE94JxMCfaXoQ/U1WA==
+      integrity: sha512-I21XON+RXsF90JVMoXZxtZB7D2DQHrTkPVlD7C2vS20Tg1um3ueviQq6U37BGCqtbRzfjLd4S7YlVvGrK8EVHg==
       tarball: 'file:projects/setup-flutter.tgz'
     version: 0.0.0
 registry: ''
@@ -3983,6 +3995,7 @@ specifiers:
   '@zeit/ncc': ~0.20.0
   jest: ^24.0.0
   jest-circus: ^24.0.0
+  jest-silent-reporter: ~0.1.0
   prettier: ^1.0.0
   semver: ^6.0.0
   ts-jest: ^24.0.0

--- a/setup-flutter/__tests__/installer.test.ts
+++ b/setup-flutter/__tests__/installer.test.ts
@@ -47,6 +47,17 @@ describe("installer tests", () => {
       installer.getPlatform()
     );
 
+    console.log(
+      fs.readdirSync(toolDir),
+      fs.readdirSync(
+        path.join(
+          toolDir,
+          "Flutter",
+          semver.clean(release.version)
+        )
+      )
+    );
+
     expect(fs.existsSync(`${flutter}.complete`)).toBe(true);
     expect(fs.existsSync(path.join(flutter, "bin", "flutter.bat"))).toBe(true);
   }, 300000);

--- a/setup-flutter/__tests__/installer.test.ts
+++ b/setup-flutter/__tests__/installer.test.ts
@@ -50,13 +50,6 @@ describe("installer tests", () => {
       installer.getPlatform()
     );
 
-    console.log(
-      fs.readdirSync(toolDir),
-      fs.readdirSync(
-        path.join(toolDir, "Flutter", semver.clean(release.version))
-      )
-    );
-
     expect(fs.existsSync(`${flutter}.complete`)).toBe(true);
     expect(fs.existsSync(path.join(flutter, "bin", "flutter.bat"))).toBe(true);
   }, 300000);

--- a/setup-flutter/__tests__/installer.test.ts
+++ b/setup-flutter/__tests__/installer.test.ts
@@ -1,30 +1,33 @@
 import * as io from "@actions/io";
 import * as fs from "fs";
-import * as os from "os";
 import * as path from "path";
 import * as semver from "semver";
 
-import * as installer from "../src/installer";
-
-let baseDirectory;
-
-switch (os.platform()) {
-  case "win32":
-    baseDirectory = process.env.USERPROFILE || "C:\\";
-    break;
-  case "darwin":
-    baseDirectory = "/Users";
-    break;
-  default:
-    baseDirectory = "/home";
-    break;
-}
-
-const tempDir = path.join(baseDirectory, "actions", "temp");
-const toolDir = path.join(baseDirectory, "actions", "cache");
+const tempDir = path.join(
+  __dirname,
+  "runner",
+  path.join(
+    Math.random()
+      .toString(36)
+      .substring(7)
+  ),
+  "temp"
+);
+const toolDir = path.join(
+  __dirname,
+  "runner",
+  path.join(
+    Math.random()
+      .toString(36)
+      .substring(7)
+  ),
+  "tools"
+);
 
 process.env.RUNNER_TEMP = tempDir;
 process.env.RUNNER_TOOL_CACHE = toolDir;
+
+import * as installer from "../src/installer";
 
 describe("installer tests", () => {
   afterAll(async () => {
@@ -50,11 +53,7 @@ describe("installer tests", () => {
     console.log(
       fs.readdirSync(toolDir),
       fs.readdirSync(
-        path.join(
-          toolDir,
-          "Flutter",
-          semver.clean(release.version)
-        )
+        path.join(toolDir, "Flutter", semver.clean(release.version))
       )
     );
 

--- a/setup-flutter/dist/index.js
+++ b/setup-flutter/dist/index.js
@@ -3144,11 +3144,28 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+// Loads `tempDirectory` before it gets wiped by tool-cache.
+let tempDir = process.env.RUNNER_TEMP || "";
 const core = __importStar(__webpack_require__(776));
 const toolCache = __importStar(__webpack_require__(32));
 const os = __importStar(__webpack_require__(87));
 const path = __importStar(__webpack_require__(622));
 const typedRestClient = __importStar(__webpack_require__(386));
+if (!tempDir) {
+    let baseLocation;
+    if (process.platform === "win32") {
+        baseLocation = process.env.USERPROFILE || "C:\\";
+    }
+    else {
+        if (process.platform === "darwin") {
+            baseLocation = "/Users";
+        }
+        else {
+            baseLocation = "/home";
+        }
+    }
+    tempDir = path.join(baseLocation, "actions", "temp");
+}
 const baseUrl = "https://storage.googleapis.com/flutter_infra/releases/";
 const flutterToolName = "Flutter";
 const restClient = new typedRestClient.RestClient("setup-flutter");

--- a/setup-flutter/dist/index.js
+++ b/setup-flutter/dist/index.js
@@ -3161,7 +3161,7 @@ function acquireFlutter(release, platform) {
         core.debug(`Extracting archive "${downloadPath}".`);
         const extPath = platform === "windows" || platform === "macos"
             ? yield toolCache.extractZip(downloadPath)
-            : yield toolCache.extractTar(downloadPath);
+            : yield toolCache.extractTar(downloadPath, undefined, "x");
         core.debug(`Extracted archive "${downloadPath}" to ${extPath}.`);
         const toolRoot = path.join(extPath, "flutter");
         core.debug(`Adding ${toolRoot} to cache (${flutterToolName}, ${release.version}, ${platform}).`);

--- a/setup-flutter/jest.config.js
+++ b/setup-flutter/jest.config.js
@@ -16,6 +16,5 @@ module.exports = {
   testRunner: 'jest-circus/runner',
   transform: {
     '^.+\\.ts$': 'ts-jest'
-  },
-  verbose: true
+  }
 };

--- a/setup-flutter/jest.config.js
+++ b/setup-flutter/jest.config.js
@@ -9,6 +9,7 @@ module.exports = {
     'js',
     'ts'
   ],
+  reporters: [],
   testEnvironment: 'node',
   testMatch: [
     '**/*.test.ts'

--- a/setup-flutter/jest.config.js
+++ b/setup-flutter/jest.config.js
@@ -9,7 +9,9 @@ module.exports = {
     'js',
     'ts'
   ],
-  reporters: [],
+  reporters: [
+    'jest-silent-reporter'
+  ],
   testEnvironment: 'node',
   testMatch: [
     '**/*.test.ts'

--- a/setup-flutter/package.json
+++ b/setup-flutter/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "ncc build src/setup-flutter.ts",
     "format": "tslint --fix --project tsconfig.json",
-    "test": "jest"
+    "test": "jest --slient"
   },
   "dependencies": {
     "@actions/core": "^1.0.0",

--- a/setup-flutter/package.json
+++ b/setup-flutter/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "ncc build src/setup-flutter.ts",
     "format": "tslint --fix --project tsconfig.json",
-    "test": "jest --slient"
+    "test": "jest --silent"
   },
   "dependencies": {
     "@actions/core": "^1.0.0",

--- a/setup-flutter/package.json
+++ b/setup-flutter/package.json
@@ -20,6 +20,7 @@
     "@zeit/ncc": "~0.20.0",
     "jest": "^24.0.0",
     "jest-circus": "^24.0.0",
+    "jest-silent-reporter": "~0.1.0",
     "prettier": "^1.0.0",
     "ts-jest": "^24.0.0",
     "tslint": "^5.0.0",

--- a/setup-flutter/package.json
+++ b/setup-flutter/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "ncc build src/setup-flutter.ts",
     "format": "tslint --fix --project tsconfig.json",
-    "test": "jest --silent"
+    "test": "jest"
   },
   "dependencies": {
     "@actions/core": "^1.0.0",

--- a/setup-flutter/src/installer.ts
+++ b/setup-flutter/src/installer.ts
@@ -1,3 +1,6 @@
+// Loads `tempDirectory` before it gets wiped by tool-cache.
+let tempDir = process.env.RUNNER_TEMP || "";
+
 import * as core from "@actions/core";
 import * as toolCache from "@actions/tool-cache";
 import * as os from "os";
@@ -6,6 +9,22 @@ import * as typedRestClient from "typed-rest-client";
 
 import { Release } from "./models/release";
 import { Releases } from "./models/releases";
+
+if (!tempDir) {
+  let baseLocation;
+
+  if (process.platform === "win32") {
+    baseLocation = process.env.USERPROFILE || "C:\\";
+  } else {
+    if (process.platform === "darwin") {
+      baseLocation = "/Users";
+    } else {
+      baseLocation = "/home";
+    }
+  }
+
+  tempDir = path.join(baseLocation, "actions", "temp");
+}
 
 const baseUrl = "https://storage.googleapis.com/flutter_infra/releases/";
 

--- a/setup-flutter/src/installer.ts
+++ b/setup-flutter/src/installer.ts
@@ -26,7 +26,7 @@ export async function acquireFlutter(
   const extPath =
     platform === "windows" || platform === "macos"
       ? await toolCache.extractZip(downloadPath)
-      : await toolCache.extractTar(downloadPath);
+      : await toolCache.extractTar(downloadPath, undefined, "x");
   core.debug(`Extracted archive "${downloadPath}" to ${extPath}.`);
 
   const toolRoot = path.join(extPath, "flutter");


### PR DESCRIPTION
## Pull Request Checklist
<!-- Check if your pull request fulfills the requirements. -->
- [x] Commit Message Follows Guidelines
- [x] Tests For Changes Have Been Added
- [ ] Docs Have Been Added Or Updated

## Current Behaviour
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The download currently fails to be extracted on Linux due to the default `extractTar` flags.

## New Behaviour
<!-- Please describe the new behavior that you have implemented. -->
The default flags of the `extractTar` method have been overridden with the correct flags.

## Other Information
<!-- List any other information that is relevant to your pull request. -->
The version of node used in the main workflow has been upgraded from `10.x` to `12.x` in order to remove the `fs.promises` experimental warning and the `jest-silent-reporter` package has been added as the default jest reporter in order to alleviate rush command failures due to console output.